### PR TITLE
feat: add speed, status & navigation_status to vessel scrapping

### DIFF
--- a/bloom/domain/vessel.py
+++ b/bloom/domain/vessel.py
@@ -11,6 +11,9 @@ class Vessel(BaseModel):
     last_position_time: datetime | None
     latitude: float | None
     longitude: float | None
+    status: str | None
+    speed: float | None
+    navigation_status: str | None
 
     def to_list(self) -> list:
         return [

--- a/bloom/infra/marine_traffic_scraper.py
+++ b/bloom/infra/marine_traffic_scraper.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime, timezone
 from logging import getLogger
 from time import sleep
@@ -79,6 +80,9 @@ class MarineTrafficVesselScraper:
                     last_position_time=record_fields[2],
                     latitude=record_fields[3],
                     longitude=record_fields[4],
+                    status=record_fields[5],
+                    speed=self.extract_speed_from_scrapped_field(record_fields[6]),
+                    navigation_status=record_fields[7],
                 )
         except WebDriverException:
             logger.exception(f"Scrapping failed for vessel {vessel.IMO}")
@@ -89,4 +93,11 @@ class MarineTrafficVesselScraper:
                 last_position_time=None,
                 latitude=None,
                 longitude=None,
+                status=None,
+                speed=None,
+                navigation_status=None,
             )
+
+    @staticmethod
+    def extract_speed_from_scrapped_field(speed_field: str) -> float:
+        return float(re.findall(r"[\d]*[.][\d]*", speed_field)[0])

--- a/bloom/infra/marine_traffic_scraper.py
+++ b/bloom/infra/marine_traffic_scraper.py
@@ -72,18 +72,6 @@ class MarineTrafficVesselScraper:
                     "IMO has changed: "
                     f"new value {record_fields[1]} vs old value {vessel.IMO}",
                 )
-            else:
-                return Vessel(
-                    timestamp=crawling_timestamp,
-                    ship_name=record_fields[0],
-                    IMO=record_fields[1],
-                    last_position_time=record_fields[2],
-                    latitude=record_fields[3],
-                    longitude=record_fields[4],
-                    status=record_fields[5],
-                    speed=self.extract_speed_from_scrapped_field(record_fields[6]),
-                    navigation_status=record_fields[7],
-                )
         except WebDriverException:
             logger.exception(f"Scrapping failed for vessel {vessel.IMO}")
             return Vessel(
@@ -97,6 +85,17 @@ class MarineTrafficVesselScraper:
                 speed=None,
                 navigation_status=None,
             )
+        return Vessel(
+            timestamp=crawling_timestamp,
+            ship_name=record_fields[0],
+            IMO=record_fields[1],
+            last_position_time=record_fields[2],
+            latitude=record_fields[3],
+            longitude=record_fields[4],
+            status=record_fields[5],
+            speed=self.extract_speed_from_scrapped_field(record_fields[6]),
+            navigation_status=record_fields[7],
+        )
 
     @staticmethod
     def extract_speed_from_scrapped_field(speed_field: str) -> float:

--- a/tests/infra/test_marine_traffic_scrapper.py
+++ b/tests/infra/test_marine_traffic_scrapper.py
@@ -63,3 +63,19 @@ def test_driver_tabs_opening():
             marine_traffic_scrapper.scrap_vessel(driver=driver, vessel=test_vessel)
 
         assert len(driver.window_handles) == 1
+
+
+def test_speed_field_is_correctly_parsed():
+    speed_field_value = "2.2 knots"
+    speed_field_value_null = "0.0 knots"
+    expected_speed = 2.2
+    expected_speed_null = 0
+    extracted_speed = MarineTrafficVesselScraper.extract_speed_from_scrapped_field(
+        speed_field_value,
+    )
+    extracted_speed_null = MarineTrafficVesselScraper.extract_speed_from_scrapped_field(
+        speed_field_value_null,
+    )
+
+    assert extracted_speed == expected_speed
+    assert extracted_speed_null == expected_speed_null


### PR DESCRIPTION
En parcourant les colonnes mises à disposition par MarineTraffic, certaines semblent intéressantes à rajouter pour la génération d'alertes : 
- Statut
- Vitesse instantanée
- [Statut de navigation](https://help.marinetraffic.com/hc/en-us/articles/203990998-What-is-the-significance-of-the-AIS-Navigational-Status-Values-)

D'autres colonnes sont disponibles : 

- Photos
- Destination Port
- Reported ETA
- Reported Destination
- Current Port
- Vessel Type - Generic
- Time of Latest Position
- Course
- Width
- Capacity - DWT
- Current Port UNLOCODE
- Current Port Country
- Callsign